### PR TITLE
Static distributed tracing

### DIFF
--- a/client/BUILD
+++ b/client/BUILD
@@ -18,4 +18,5 @@ java_library(
         "//dependencies/maven/artifacts/io/netty:netty-tcnative-boringssl-static",
     ],
     visibility = ["//visibility:public"],
+    tags = ["maven_coordinates=io.grabl.tracing:grabl-tracing-client:{pom_version}"],
 )

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -25,4 +25,5 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-stub",
         "//dependencies/maven/artifacts/io/grpc:grpc-api",
     ],
+    tags = ["maven_coordinates=io.grabl.tracing:grabl-tracing-protocol:{pom_version}"],
 )

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,4 +3,5 @@ java_library(
     srcs = glob(["*.java"]),
     deps = ["//dependencies/maven/artifacts/com/google/protobuf:protobuf-java"],
     visibility = ["//visibility:public"],
+    tags = ["maven_coordinates=io.grabl.tracing:grabl-tracing-util:{pom_version}"],
 )


### PR DESCRIPTION
## What is the goal of this PR?

In grabl tracing, distributed tracing works by creating a trace directly from the client given its parent's `rootId` and `id`. This method was not supported by `GrablTracingThreadStatic` since it was analysis centric, so we have adjusted the API to be client centric so that it can achieve both. This means dependents will need to be updated slightly.

## What are the changes implemented in this PR?

- Drive-by: Added maven coordinates (fixed bazel issues with `java_deps`, but does not include maven deployment)
- Refactored `GrablTracingThreadStatic` to supply both client and analysis level tracing.