### PR TITLE
Add tracing client getter to static tracing

### DIFF
--- a/client/GrablTracingThreadStatic.java
+++ b/client/GrablTracingThreadStatic.java
@@ -44,6 +44,15 @@ public class GrablTracingThreadStatic {
     }
 
     /**
+     * Get the current singleton grabl tracing client. The user should always call {@link #isTracingEnabled()} first.
+     *
+     * @return the singleton grabl tracing client
+     */
+    public static GrablTracing getGrablTracing() {
+        return singletonClient;
+    }
+
+    /**
      * Set the Analysis for the application and enable tracing globally beyond this point.
      *
      * @param owner The Grabl tracing repo owner to set.


### PR DESCRIPTION
## What is the goal of this PR?

Occasionally we need to create traces that are not managed on the local thread (to be passed between threads), so we need to allow the user to get the grabl tracing client and create the threads manually.

## What are the changes implemented in this PR?

- Added a getter for the singleton tracing client.