### PR TITLE
Fix tracing without an analysis and upgrade tracing server slightly

### DIFF
--- a/client/GrablTracingThreadStatic.java
+++ b/client/GrablTracingThreadStatic.java
@@ -84,13 +84,17 @@ public class GrablTracingThreadStatic {
      * @return A try-with-resources representation of the Trace and its existence on the thread's stack.
      */
     public static ThreadTrace traceOnThread(String name) {
-        if (!ANALYSIS_SET.get()) {
+        if (!ENABLED.get()) {
             return THREAD_TRACE_NO_OP;
         }
 
         ThreadTrace stacked = traceStack.peek();
         if (stacked != null) {
             return stacked.traceOnThread(name);
+        }
+
+        if (!ANALYSIS_SET.get()) {
+            return THREAD_TRACE_NO_OP;
         }
 
         ThreadContext context = contextStack.peek();

--- a/test/TestTracingServer.java
+++ b/test/TestTracingServer.java
@@ -25,20 +25,24 @@ public class TestTracingServer extends TracingServiceImplBase {
 
     @Override
     public void create(Analysis.Req request, StreamObserver<Analysis.Res> responseObserver) {
+        System.out.println("Create Request: " + request);
         UUID id = UUID.randomUUID();
         Analysis.Res response = Analysis.Res.newBuilder()
                 .setAnalysisId(toBuf(id))
                 .build();
+        System.out.println("Create Response: " + response);
         responseObserver.onNext(response);
         responseObserver.onCompleted();
     }
 
     @Override
     public StreamObserver<Trace.Req> stream(StreamObserver<Trace.Res> responseObserver) {
+        System.out.println("Trace Stream Started");
+
         return new StreamObserver<Trace.Req>() {
             @Override
             public void onNext(Trace.Req req) {
-                System.out.print(req);
+                System.out.print("Trace Request: " + req);
             }
 
             @Override
@@ -49,6 +53,7 @@ public class TestTracingServer extends TracingServiceImplBase {
             @Override
             public void onCompleted() {
                 responseObserver.onNext(Trace.Res.newBuilder().build());
+                System.out.println("Trace Stream Completed");
                 responseObserver.onCompleted();
             }
         };


### PR DESCRIPTION
## What is the goal of this PR?

To fix a bug where static tracing without setting an analysis would not allow starting traces on the thread even when a non-analysis trace was already present.

## What are the changes implemented in this PR?

- Fixed bug where stack was not checked before checking for analysis
- Added more output to the test tracing server