### PR TITLE
Fix wrong maven dep name in test deployment pom

### DIFF
--- a/test/deployment/pom.xml
+++ b/test/deployment/pom.xml
@@ -7,6 +7,10 @@
     <version>1.0-SNAPSHOT</version>
     <name>test-deployment</name>
     <url>http://maven.apache.org</url>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
     <repositories>
         <repository>
             <id>repo.grakn.ai.release</id>

--- a/test/deployment/pom.xml
+++ b/test/deployment/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>io.grabl.tracing</groupId>
-            <artifactId>grabl-tracing</artifactId>
+            <artifactId>grabl-tracing-client</artifactId>
             <version>GRABL_TRACING_VERSION_MARKER</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What is the goal of this PR?

To fix the dependency artifact name being incorrect in `test/deployment/pom.xml`