### PR TITLE
Permit tracing no-op when context not supplied

### DIFF
--- a/client/GrablTracingThreadStatic.java
+++ b/client/GrablTracingThreadStatic.java
@@ -99,7 +99,7 @@ public class GrablTracingThreadStatic {
 
         ThreadContext context = contextStack.peek();
         if (context == null) {
-            throw new IllegalStateException("No context found: must be in a ThreadContext");
+            return THREAD_TRACE_NO_OP;
         }
 
         return new ThreadTraceImpl(singletonAnalysis.trace(name, context.getTracker(), context.getIteration()));


### PR DESCRIPTION
## What is the goal of this PR?

We update the behaviour such that not providing a context is taken as an indication that the user doesn't want tracing enabled.

## What are the changes implemented in this PR?

- Replaces an exception with a no-op
