### PR TITLE
Ping keep alive so that tracing stream doesn't get dropped during idle

### DIFF
--- a/client/GrablTracing.java
+++ b/client/GrablTracing.java
@@ -3,6 +3,7 @@ package grabl.tracing.client;
 import io.grpc.ManagedChannelBuilder;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Grabl Tracing client.
@@ -116,6 +117,8 @@ public interface GrablTracing extends AutoCloseable {
     static GrablTracing tracing(String grablUri, String username, String apiToken) {
         return new GrablTracingStandard(
                 ManagedChannelBuilder.forTarget(grablUri)
+                        .keepAliveTime(1, TimeUnit.MINUTES)
+                        .keepAliveWithoutCalls(true)
                         .useTransportSecurity()
                         .intercept(new GrablTokenAuthClientInterceptor(username, apiToken))
                         .build()
@@ -132,6 +135,8 @@ public interface GrablTracing extends AutoCloseable {
     static GrablTracing tracing(String grablUri) {
         return new GrablTracingStandard(
                 ManagedChannelBuilder.forTarget(grablUri)
+                        .keepAliveTime(1, TimeUnit.MINUTES)
+                        .keepAliveWithoutCalls(true)
                         .usePlaintext()
                         .build()
         );


### PR DESCRIPTION
Currently grakn core tracing doesn't work, due to the fact that grakn server initiates the tracing stream on start up, and by the time the simulation program starts to stream data, the grakn-grabl connection is already dropped due to timeout.

We need to send keep alive ping to the server.

The dual PR on server is https://github.com/graknlabs/grabl/pull/1379.