### PR TITLE
Remove sync-dependencies from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,8 @@ workflows:
           filters:
             branches:
               only: master
-
+          requires:
+            - test-deployment-maven
   grabl-tracing-release:
     jobs:
       - deploy-github:
@@ -208,3 +209,5 @@ workflows:
           filters:
             branches:
               only: grabl-tracing-release-branch
+          requires:
+            - deploy-maven-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,18 +180,10 @@ workflows:
               only: master
           requires:
             - deploy-maven-snapshot
-      - sync-dependencies-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-deployment-maven
       - release-approval:
           filters:
             branches:
               only: master
-          requires:
-            - sync-dependencies-snapshot
 
   grabl-tracing-release:
     jobs:
@@ -212,15 +204,7 @@ workflows:
               only: grabl-tracing-release-branch
           requires:
             - deploy-approval
-      - sync-dependencies-release:
-          filters:
-            branches:
-              only: grabl-tracing-release-branch
-          requires:
-            - deploy-maven-release
       - release-cleanup:
           filters:
             branches:
               only: grabl-tracing-release-branch
-          requires:
-            - sync-dependencies-release


### PR DESCRIPTION
## What is the goal of this PR?

We have removed sync-dependencies completely. It will be replaced by Grabl 2.0's sync pipeline soon.