### PR TITLE
Refactor: clean up to use 2.0 build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -21,13 +21,15 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["VERSION"], visibility = ["//visibility:public"])
 
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
+load("//:deployment.bzl", "deployment")
 
-exports_files(["VERSION", "RELEASE_TEMPLATE.md", "deployment.properties"])
+exports_files(["VERSION", "RELEASE_TEMPLATE.md"])
 
 deploy_github(
     name = "deploy-github",
     release_description = "//:RELEASE_TEMPLATE.md",
     title = "Grabl Tracing API and Client",
     title_append_version = True,
-    deployment_properties = "//:deployment.properties",
+    organisation = deployment["github.organisation"],
+    repository = deployment["github.repository"]
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,7 +60,7 @@ kt_register_toolchains()
 # Load NodeJS
 load("@graknlabs_dependencies//builder/nodejs:deps.bzl", nodejs_deps = "deps")
 nodejs_deps()
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
 node_repositories()
 
 # Load Python
@@ -92,14 +92,11 @@ sonarcloud_dependencies()
 load("@graknlabs_dependencies//tool/unuseddeps:deps.bzl", unuseddeps_deps = "deps")
 unuseddeps_deps()
 
-load("@graknlabs_dependencies//distribution:deps.bzl", distribution_deps = "deps")
-distribution_deps()
+#####################################################################
+# Load @graknlabs_bazel_distribution (from @graknlabs_dependencies) #
+#####################################################################
 
-#######################################
-# Load @graknlabs_bazel_distribution  #
-#######################################
-
-load("//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
+load("@graknlabs_dependencies//dependencies/graknlabs:repositories.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
 pip3_import(
@@ -112,25 +109,6 @@ graknlabs_bazel_distribution_pip_install()
 
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
 tcnksm_ghr()
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/graknlabs/skydoc.git",
-    branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-)
-
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
-
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
 
 load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
 bazelbuild_rules_pkg()

--- a/client/BUILD
+++ b/client/BUILD
@@ -22,7 +22,7 @@ package(default_visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
 load("//dependencies/maven:artifacts.bzl", maven_overrides_repo = "overrides")
-
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 
 java_library(
     name = "client",
@@ -60,5 +60,6 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    deployment_properties = "@graknlabs_dependencies//distribution:deployment.properties",
+    snapshot = deployment["maven.snapshot"],
+    release = deployment["maven.release"],
 )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -18,16 +18,9 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-def graknlabs_bazel_distribution():
-    git_repository(
-        name = "graknlabs_bazel_distribution",
-        remote = "https://github.com/graknlabs/bazel-distribution",
-        commit = "30e30cec9e3fe4821103cafbd240ee9862e262ea" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_bazel_distribution
-    )
-
 def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "07127f135b7f3a1f9a18ab44aba69fa0169df1dc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "2680ead7ed779bf2835953852789dfeb3f25d7a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/deployment.bzl
+++ b/deployment.bzl
@@ -17,5 +17,7 @@
 # under the License.
 #
 
-repo.github.organisation=graknlabs
-repo.github.repository=grabl-tracing
+deployment = {
+    "github.organisation" : "graknlabs",
+    "github.repository" : "grabl-tracing"
+}

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -21,6 +21,7 @@ package(default_visibility = ["//visibility:public"])
 load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
 load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
+load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
 load("//dependencies/maven:artifacts.bzl", maven_overrides_repo = "overrides")
 
 proto_library(
@@ -67,5 +68,6 @@ assemble_maven(
 deploy_maven(
     name = "deploy-maven",
     target = ":assemble-maven",
-    deployment_properties = "@graknlabs_dependencies//distribution:deployment.properties",
+    snapshot = deployment["maven.snapshot"],
+    release = deployment["maven.release"]
 )


### PR DESCRIPTION
## What is the goal of this PR?
Update to use cleaned up assemble-maven, deployment targets, and new format of deployment properties in `deployment.bzl`. Also clean up WORKSPACE to remove `sass` targets that are not required.

