### PR TITLE
Refactor to use new declarations for org and repo artifacts

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -98,10 +98,8 @@ github_deps()
 ################################
 
 load("@graknlabs_dependencies//library/maven:rules.bzl", "maven")
-load("//dependencies/maven:artifacts.bzl",
-    maven_artifacts = "artifacts",
-    maven_overrides = "overrides")
-maven(maven_artifacts, maven_overrides)
+load("//dependencies/maven:artifacts.bzl", "artifacts", "artifacts_repo")
+maven(artifacts, artifacts_repo)
 
 ##################################################
 # Create @graknlabs_grabl_tracing_workspace_refs #

--- a/client/BUILD
+++ b/client/BUILD
@@ -20,9 +20,11 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
-load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
-load("//dependencies/maven:artifacts.bzl", maven_overrides_repo = "overrides")
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
+load("@graknlabs_dependencies//distribution/maven:version.bzl", "version")
+load("@graknlabs_dependencies//library/maven:artifacts.bzl", artifacts_org = "artifacts")
+load("//dependencies/maven:artifacts.bzl", "artifacts_repo")
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 
 java_library(
     name = "client",
@@ -50,7 +52,7 @@ assemble_maven(
     target = "//client",
     package = "",
     workspace_refs = "@graknlabs_grabl_tracing_workspace_refs//:refs.json",
-    version_overrides = maven_overrides(maven_overrides_org, maven_overrides_repo),
+    version_overrides = version(artifacts_org, artifacts_repo),
     project_name = "Grabl Tracing Client",
     project_description = "Grabl Tracing API and Client",
     project_url = "https://github.com/graknlabs/grabl-tracing",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -22,5 +22,5 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "1c86421327bec68a83c3f88d728add07010f797a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "a6dd66c50b77153b11473919e39e4a687534d126", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -18,7 +18,7 @@ artifacts = [
 ]
 
 # Override libraries conflicting with versions defined in @graknlabs_dependencies
-overrides = {
+artifacts_repo = {
     "io.netty:netty-all": "4.1.38.Final",
     "io.netty:netty-codec-http2": "4.1.38.Final",
     "io.netty:netty-handler": "4.1.38.Final",

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -19,10 +19,11 @@
 
 package(default_visibility = ["//visibility:public"])
 load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
-load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
-load("@graknlabs_dependencies//library/maven:artifacts.bzl", "maven_overrides", maven_overrides_org = "artifacts")
 load("@graknlabs_dependencies//distribution:deployment.bzl", "deployment")
-load("//dependencies/maven:artifacts.bzl", maven_overrides_repo = "overrides")
+load("@graknlabs_dependencies//distribution/maven:version.bzl", "version")
+load("@graknlabs_dependencies//library/maven:artifacts.bzl", artifacts_org = "artifacts")
+load("//dependencies/maven:artifacts.bzl", "artifacts_repo")
+load("@graknlabs_bazel_distribution//maven:rules.bzl", "assemble_maven", "deploy_maven")
 
 proto_library(
     name = "tracing-proto",
@@ -58,7 +59,7 @@ assemble_maven(
     target = "//protocol",
     package = "",
     workspace_refs = "@graknlabs_grabl_tracing_workspace_refs//:refs.json",
-    version_overrides = maven_overrides(maven_overrides_org, maven_overrides_repo),
+    version_overrides = version(artifacts_org, artifacts_repo),
     project_name = "Grabl Tracing Protocol",
     project_description = "Grabl Tracing Protocol",
     project_url = "https://github.com/graknlabs/grabl-tracing",


### PR DESCRIPTION
## What is the goal of this PR?
Refactor to use new declarations for org and repo artifacts

## What are the changes implemented in this PR?
* Use `artifacts_repo` and `artifacts_org` consistently across `assemble-maven` and `maven()` targets 