### PR TITLE
Adapt to new Grabl syntax

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -28,31 +28,31 @@ build:
       owner: graknlabs
       branch: master
     dependency-analysis:
-      machine: graknlabs-ubuntu-20.04-java11
+      image: graknlabs-ubuntu-20.04-java11
       script: |
         bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         bazel build --config=rbe //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
         bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     test-client:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         bazel test --config=rbe //client/test --test_output=errors
     deploy-maven-snapshot:
       filter:
         owner: graknlabs
         branch: master
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -63,7 +63,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         sed -i -e "s/GRABL_TRACING_VERSION_MARKER/$(git rev-parse HEAD)/g" test/deployment/pom.xml
         cat test/deployment/pom.xml
@@ -76,7 +76,7 @@ release:
     branch: master
   deployment:
     deploy-github:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       script: |
         pip install certifi
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
@@ -84,7 +84,7 @@ release:
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
         bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       script: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME


### PR DESCRIPTION
## What is the goal of this PR?

Grabl recently changed the `automation.yml` syntax to have `image` instead of `machine`

## What are the changes implemented in this PR?

Replace all `machine:` usages with `image:`