### PR TITLE
Update grabl automation yaml syntax

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -29,32 +29,32 @@ build:
       branch: master
     dependency-analysis:
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         bazel run @graknlabs_dependencies//grabl/analysis:dependency-analysis
   correctness:
     build:
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         bazel build //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
         bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     # TODO: enable once the test is fixed for Java 11
     # test-client:
     #   image: graknlabs-ubuntu-20.04
-    #   script: |
+    #   command: |
     #     bazel test //client/test --test_output=errors
     deploy-maven-snapshot:
       filter:
         owner: graknlabs
         branch: master
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(git rev-parse HEAD) //client:deploy-maven -- snapshot
@@ -65,7 +65,7 @@ build:
         owner: graknlabs
         branch: master
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         sed -i -e "s/GRABL_TRACING_VERSION_MARKER/$(git rev-parse HEAD)/g" test/deployment/pom.xml
         cat test/deployment/pom.xml
         cd test/deployment && mvn test
@@ -78,7 +78,7 @@ release:
   deployment:
     deploy-github:
       image: graknlabs-ubuntu-20.04
-      script: |
+      command: |
         pip install certifi
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- grabl-tracing $(cat VERSION) ./RELEASE_TEMPLATE.md
@@ -87,7 +87,7 @@ release:
     deploy-maven-release:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
-      script: |
+      command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
         bazel run --define version=$(cat VERSION) //protocol:deploy-maven -- release


### PR DESCRIPTION
## What is the goal of this PR?

Recently we added the support for background `monitor` script. Therefore we change the foreground job script from `script` to `command`.
