### PR TITLE
Reenable remote build caching

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,11 +24,8 @@ test --incompatible_strict_action_env
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
 build:rbe --remote_cache=cloud.buildbuddy.io
-build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
-build:rbe --jobs=50
 build:rbe --remote_timeout=3600

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -35,15 +35,15 @@ build:
     build:
       image: graknlabs-ubuntu-20.04
       command: |
-        bazel build //...
+        bazel build --config=rbe //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)')
+        bazel test --config=rbe $(bazel query 'kind(checkstyle_test, //...)')
     build-dependency:
       image: graknlabs-ubuntu-20.04
       command: |
         dependencies/maven/update.sh
         git diff --exit-code dependencies/maven/artifacts.snapshot
-        bazel run @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
+        bazel run --config=rbe @graknlabs_dependencies//tool/unuseddeps:unused-deps -- list
     # TODO: enable once the test is fixed for Java 11
     # test-client:
     #   image: graknlabs-ubuntu-20.04
@@ -57,8 +57,8 @@ build:
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(git rev-parse HEAD) //client:deploy-maven -- snapshot
-        bazel run --define version=$(git rev-parse HEAD) //protocol:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //client:deploy-maven -- snapshot
+        bazel run --config=rbe --define version=$(git rev-parse HEAD) //protocol:deploy-maven -- snapshot
       dependencies: [build, build-dependency] # TODO: make it depend on test-client once fixed
     test-deployment-maven:
       filter:
@@ -83,12 +83,12 @@ release:
         export RELEASE_NOTES_TOKEN=$REPO_GITHUB_TOKEN
         bazel run @graknlabs_dependencies//tool/release:create-notes -- grabl-tracing $(cat VERSION) ./RELEASE_TEMPLATE.md
         export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
+        bazel run --config=rbe --define version=$(cat VERSION) //:deploy-github -- $GRABL_COMMIT
     deploy-maven-release:
       image: graknlabs-ubuntu-20.04
       dependencies: [deploy-github]
       command: |
         export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel run --define version=$(cat VERSION) //protocol:deploy-maven -- release
-        bazel run --define version=$(cat VERSION) //client:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //protocol:deploy-maven -- release
+        bazel run --config=rbe --define version=$(cat VERSION) //client:deploy-maven -- release


### PR DESCRIPTION
## What is the goal of this PR?

Speed up builds by utilizing remote caching provided by BuildBuddy.

## What are the changes implemented in this PR?

Reenable build caching (without remote execution) on all CI jobs